### PR TITLE
DEV: Remove bulk select still active

### DIFF
--- a/javascripts/discourse/api-initializers/fkb-template.js
+++ b/javascripts/discourse/api-initializers/fkb-template.js
@@ -76,26 +76,6 @@ export default {
           });
         },
       });
-
-      api.onPageChange((url, title) => {
-        const currentUser = api.getCurrentUser();
-        const router = api.container.lookup("service:router");
-        const newRouteDiscovery = router.currentRouteName === "discovery.new";
-        const unreadRouteDiscovery = router.currentRouteName === "discovery.unread";
-        const bodyHasBulkSelectClass = document.body.classList.contains("bulk-select-enabled");
-        
-        if ((!newRouteDiscovery && 
-            bodyHasBulkSelectClass && 
-            currentUser && !currentUser.staff) && 
-            (!unreadRouteDiscovery && 
-            bodyHasBulkSelectClass && 
-            currentUser && !currentUser.staff))
-        {
-          document.body.classList.add("bulk-still-active");
-        } else {
-          document.body.classList.remove("bulk-still-active");
-        }
-      });
       
       api.onPageChange((url, title) => {
         const fkbHidden = localStorage.getItem("fkb_panel_hidden") === "true";

--- a/scss/common/fkb-c-bulk-select.scss
+++ b/scss/common/fkb-c-bulk-select.scss
@@ -3,7 +3,7 @@
   .user-messages-page,
   body[class*="tag-"]:not(.archetype-regular):not(.archetype-banner),
   body[class*="category-"]:not(.archetype-regular):not(.archetype-banner) {
-    &.bulk-select-enabled:not(.bulk-still-active) {
+    &.bulk-select-enabled {
       .mobile-view & {
         .list-controls {
           .navigation-container {
@@ -170,21 +170,6 @@
               &.selected {
                 background: rgba(var(--tertiary-rgb), 0.3);
               }
-            }
-          }
-        }
-      }
-    }
-  }
-  
-  // Bulk select still active on other pages
-  body.bulk-select-enabled {
-    &.bulk-still-active {
-      .topic-list {
-        .topic-list-item {
-          .topic-list-data {
-            &.bulk-select {
-              display: none;
             }
           }
         }


### PR DESCRIPTION
This was fixed with: https://github.com/discourse/discourse/pull/29984
So the theme modification is removable now.